### PR TITLE
Add prettier and pre-commit hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4236,14 +4236,6 @@
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
       "dev": true
     },
-    "connected-react-router": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-4.4.1.tgz",
-      "integrity": "sha512-2QiSQPjqePkblAdctpCtWLskwu4WcZe+iYGMH8epUIVga87tNEdT005/nluVC7lHdmPIKVB4lW3tSuldYYcPZw==",
-      "requires": {
-        "immutable": "^3.8.1"
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -5571,6 +5563,23 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.1.0.tgz",
+      "integrity": "sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -5703,6 +5712,15 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz",
+      "integrity": "sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -6439,6 +6457,12 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -6778,14 +6802,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6805,8 +6827,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6954,7 +6975,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6962,8 +6982,7 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
@@ -8108,7 +8127,8 @@
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+      "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -12165,6 +12185,21 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.1.tgz",
+      "integrity": "sha512-4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-error": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3115,6 +3115,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bootstrap": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4235,6 +4240,16 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
       "dev": true
+    },
+    "connected-react-router": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-4.5.0.tgz",
+      "integrity": "sha512-SBBmAZrtmw4y7Rkl2PCct8lN/DuCftl7QSAFLgFyjjuYkeJKAzAvQjzNNNE4R3j2+6a4TUiv8qselxQ4+6H5eA==",
+      "requires": {
+        "immutable": "^3.8.1",
+        "redux-seamless-immutable": "^0.4.0",
+        "seamless-immutable": "^7.1.3"
+      }
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -8127,8 +8142,7 @@
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
-      "dev": true
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -12575,6 +12589,11 @@
         "warning": "^4.0.1"
       }
     },
+    "react-router-redux": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
+      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
+    },
     "react-test-renderer": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.2.tgz",
@@ -12728,6 +12747,15 @@
       "dev": true,
       "requires": {
         "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "redux-seamless-immutable": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/redux-seamless-immutable/-/redux-seamless-immutable-0.4.0.tgz",
+      "integrity": "sha512-/oS3fhrize9D3RSHemgJxVllohybRrad5IjccotFy8Ni4IKAPTtX1mqszpiCIl12+7v0dNqBpq6ES6R236AliQ==",
+      "requires": {
+        "react-router-redux": "^4.0.0",
+        "seamless-immutable": "^7.1.2"
       }
     },
     "redux-thunk": {
@@ -13677,6 +13705,11 @@
           }
         }
       }
+    },
+    "seamless-immutable": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
+      "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "open:dist": "babel-node tools/distServer.js",
     "lint": "esw webpack.config.* src tools --color",
     "lint:watch": "npm run lint -- --watch",
-    "style": "prettier --config=./package.json --write src/**/*.js tools/**/*.js",
+    "style": "prettier --config=./package.json --write 'src/**/*.js' 'tools/**/*.js'",
     "clean-dist": "npm run remove-dist && mkdir dist",
     "remove-dist": "rimraf ./dist",
     "prebuild": "npm run lint && npm run test && npm run clean-dist",
@@ -104,6 +104,17 @@
   "repository": {
     "type": "git",
     "url": ""
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "open:dist": "babel-node tools/distServer.js",
     "lint": "esw webpack.config.* src tools --color",
     "lint:watch": "npm run lint -- --watch",
+    "style": "prettier --config=./package.json --write src/**/*.js tools/**/*.js",
     "clean-dist": "npm run remove-dist && mkdir dist",
     "remove-dist": "rimraf ./dist",
     "prebuild": "npm run lint && npm run test && npm run clean-dist",
@@ -63,7 +64,9 @@
     "enzyme": "3.5.0",
     "enzyme-adapter-react-16": "1.3.1",
     "eslint": "5.4.0",
+    "eslint-config-prettier": "3.1.0",
     "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
     "eslint-watch": "4.0.2",
     "file-loader": "2.0.0",
@@ -79,6 +82,7 @@
     "node-sass": "4.9.3",
     "opn-cli": "3.1.0",
     "postcss-loader": "3.0.0",
+    "prettier": "1.15.1",
     "prompt": "1.0.0",
     "prop-types": "15.6.2",
     "raf": "3.4.0",
@@ -156,13 +160,15 @@
   "eslintConfig": {
     "root": true,
     "extends": [
+      "prettier",
       "eslint:recommended",
       "plugin:import/errors",
       "plugin:import/warnings",
       "plugin:react/recommended"
     ],
     "plugins": [
-      "react"
+      "react",
+      "prettier"
     ],
     "parser": "babel-eslint",
     "parserOptions": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,15 +1,15 @@
-import React from 'react';
+import React from "react";
 
-import Navbar from './nav/Navbar';
+import Navbar from "./nav/Navbar";
 
 class App extends React.Component {
-  render () {
+  render() {
     return (
       <div>
-        <Navbar/>
+        <Navbar />
       </div>
-    )
+    );
   }
 }
 
-export default App
+export default App;

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { ConnectedRouter } from 'connected-react-router';
-import { Provider } from 'react-redux';
-import App from './App';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { ConnectedRouter } from "connected-react-router";
+import { Provider } from "react-redux";
+import App from "./App";
 
 export default class Root extends Component {
   render() {

--- a/src/components/emptyTest.spec.js
+++ b/src/components/emptyTest.spec.js
@@ -1,6 +1,5 @@
 // Must have at least one test file in this directory or Mocha will throw an error.
 
-describe('emptyTest', () => {
-  it('', () => {
-  })
-})
+describe("emptyTest", () => {
+  it("", () => {});
+});

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -1,13 +1,15 @@
-import React from 'react';
+import React from "react";
 
 class Navbar extends React.Component {
-  render () {
+  render() {
     return (
       <nav className="navbar navbar-dark bg-dark">
-        <a className="navbar-brand" href="#">myHive</a>
+        <a className="navbar-brand" href="#">
+          myHive
+        </a>
       </nav>
-    )
+    );
   }
 }
 
-export default Navbar
+export default Navbar;

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,33 @@
 /* eslint-disable */
 // Set up your application entry point here...
 
-import { render } from 'react-dom'
-import React from 'react';
+import { render } from "react-dom";
+import React from "react";
 
-import { AppContainer } from 'react-hot-loader'
+import { AppContainer } from "react-hot-loader";
 
-import Root from './components/Root';
-import configureStore, { history } from './store/configureStore'
+import Root from "./components/Root";
+import configureStore, { history } from "./store/configureStore";
 
-import './styles/styles.scss';
+import "./styles/styles.scss";
 
-const store = configureStore()
+const store = configureStore();
 
 render(
   <AppContainer>
-    <Root store={store} history={history}/>
+    <Root store={store} history={history} />
   </AppContainer>,
-  document.getElementById('app')
-)
+  document.getElementById("app")
+);
 
 if (module.hot) {
-  module.hot.accept('./components/Root', () => {
-    const NewRoot = require('./components/Root').default;
+  module.hot.accept("./components/Root", () => {
+    const NewRoot = require("./components/Root").default;
     render(
       <AppContainer>
         <NewRoot store={store} history={history} />
       </AppContainer>,
-      document.getElementById('app')
+      document.getElementById("app")
     );
   });
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,4 @@
 // Set up your root reducer here...
-import { combineReducers } from 'redux';
-const rootReducer = combineReducers({
-})
+import { combineReducers } from "redux";
+const rootReducer = combineReducers({});
 export default rootReducer;

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,10 +1,10 @@
-import {createStore, compose, applyMiddleware} from 'redux';
-import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
-import thunk from 'redux-thunk';
-import createHistory from 'history/createBrowserHistory';
+import { createStore, compose, applyMiddleware } from "redux";
+import reduxImmutableStateInvariant from "redux-immutable-state-invariant";
+import thunk from "redux-thunk";
+import createHistory from "history/createBrowserHistory";
 // 'routerMiddleware': the new way of storing route changes with redux middleware since rrV4.
-import { connectRouter, routerMiddleware } from 'connected-react-router';
-import rootReducer from '../reducers';
+import { connectRouter, routerMiddleware } from "connected-react-router";
+import rootReducer from "../reducers";
 
 export const history = createHistory();
 const connectRouterHistory = connectRouter(history);
@@ -17,12 +17,12 @@ function configureStoreProd(initialState) {
     // thunk middleware can also accept an extra argument to be passed to each thunk action
     // https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument
     thunk,
-    reactRouterMiddleware,
+    reactRouterMiddleware
   ];
 
   return createStore(
-    connectRouterHistory(rootReducer), 
-    initialState, 
+    connectRouterHistory(rootReducer),
+    initialState,
     compose(applyMiddleware(...middlewares))
   );
 }
@@ -38,20 +38,21 @@ function configureStoreDev(initialState) {
     // thunk middleware can also accept an extra argument to be passed to each thunk action
     // https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument
     thunk,
-    reactRouterMiddleware,
+    reactRouterMiddleware
   ];
 
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // add support for Redux dev tools
+  const composeEnhancers =
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // add support for Redux dev tools
   const store = createStore(
-    connectRouterHistory(rootReducer),  
-    initialState, 
+    connectRouterHistory(rootReducer),
+    initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   );
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
-    module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers').default; // eslint-disable-line global-require
+    module.hot.accept("../reducers", () => {
+      const nextRootReducer = require("../reducers").default; // eslint-disable-line global-require
       store.replaceReducer(connectRouterHistory(nextRootReducer));
     });
   }
@@ -59,6 +60,9 @@ function configureStoreDev(initialState) {
   return store;
 }
 
-const configureStore = process.env.NODE_ENV === 'production' ? configureStoreProd : configureStoreDev;
+const configureStore =
+  process.env.NODE_ENV === "production"
+    ? configureStoreProd
+    : configureStoreDev;
 
 export default configureStore;

--- a/src/webpack-public-path.js
+++ b/src/webpack-public-path.js
@@ -6,4 +6,5 @@
 // 3. https://github.com/coryhouse/react-slingshot/pull/125
 // Documentation: https://webpack.js.org/configuration/output/#output-publicpath
 // eslint-disable-next-line no-undef
-__webpack_public_path__ = window.location.protocol + "//" + window.location.host + "/";
+__webpack_public_path__ =
+  window.location.protocol + "//" + window.location.host + "/";

--- a/tools/analyzeBundle.js
+++ b/tools/analyzeBundle.js
@@ -1,10 +1,10 @@
-import webpack from 'webpack';
-import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
-import config from '../webpack.config.prod';
+import webpack from "webpack";
+import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
+import config from "../webpack.config.prod";
 
 config.plugins.push(new BundleAnalyzerPlugin());
 
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = "production";
 
 const compiler = webpack(config);
 

--- a/tools/assetsTransformer.js
+++ b/tools/assetsTransformer.js
@@ -1,14 +1,14 @@
 //---------------------------------------------------------------------
 // This is a fix for jest handling static assets like imported images
-// when running tests. It's configured in jest section of package.json 
+// when running tests. It's configured in jest section of package.json
 //
 // See:
 // https://github.com/facebook/jest/issues/2663#issuecomment-317109798
 //---------------------------------------------------------------------
-const path = require('path');
+const path = require("path");
 
 module.exports = {
   process(src, filename /*, config, options */) {
-    return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';';
-  },
+    return "module.exports = " + JSON.stringify(path.basename(filename)) + ";";
+  }
 };

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,16 +1,24 @@
 // More info on Webpack's Node API here: https://webpack.js.org/api/node/
 // Allowing console calls below since this is a build file.
 /* eslint-disable no-console */
-import webpack from 'webpack';
-import config from '../webpack.config.prod';
-import {chalkError, chalkSuccess, chalkWarning, chalkProcessing} from './chalkConfig';
+import webpack from "webpack";
+import config from "../webpack.config.prod";
+import {
+  chalkError,
+  chalkSuccess,
+  chalkWarning,
+  chalkProcessing
+} from "./chalkConfig";
 
-process.env.NODE_ENV = 'production'; // this assures React is built in prod mode and that the Babel dev config doesn't apply.
+process.env.NODE_ENV = "production"; // this assures React is built in prod mode and that the Babel dev config doesn't apply.
 
-console.log(chalkProcessing('Generating minified bundle. This will take a moment...'));
+console.log(
+  chalkProcessing("Generating minified bundle. This will take a moment...")
+);
 
 webpack(config).run((error, stats) => {
-  if (error) { // so a fatal error occurred. Stop here.
+  if (error) {
+    // so a fatal error occurred. Stop here.
     console.log(chalkError(error));
     return 1;
   }
@@ -22,14 +30,18 @@ webpack(config).run((error, stats) => {
   }
 
   if (jsonStats.hasWarnings) {
-    console.log(chalkWarning('Webpack generated the following warnings: '));
+    console.log(chalkWarning("Webpack generated the following warnings: "));
     jsonStats.warnings.map(warning => console.log(chalkWarning(warning)));
   }
 
   console.log(`Webpack stats: ${stats}`);
 
   // if we got this far, the build succeeded.
-  console.log(chalkSuccess('Your app is compiled in production mode in /dist. It\'s ready to roll!'));
+  console.log(
+    chalkSuccess(
+      "Your app is compiled in production mode in /dist. It's ready to roll!"
+    )
+  );
 
   return 0;
 });

--- a/tools/chalkConfig.js
+++ b/tools/chalkConfig.js
@@ -1,5 +1,5 @@
 // Centralized configuration for chalk, which is used to add color to console.log statements.
-import chalk from 'chalk';
+import chalk from "chalk";
 export const chalkError = chalk.red;
 export const chalkSuccess = chalk.green;
 export const chalkWarning = chalk.yellow;

--- a/tools/distServer.js
+++ b/tools/distServer.js
@@ -1,13 +1,13 @@
 // This file configures a web server for testing the production build
 // on your local machine.
 
-import browserSync from 'browser-sync';
-import historyApiFallback from 'connect-history-api-fallback';
-import {chalkProcessing} from './chalkConfig';
+import browserSync from "browser-sync";
+import historyApiFallback from "connect-history-api-fallback";
+import { chalkProcessing } from "./chalkConfig";
 
 /* eslint-disable no-console */
 
-console.log(chalkProcessing('Opening production build...'));
+console.log(chalkProcessing("Opening production build..."));
 
 // Run Browsersync
 browserSync({
@@ -16,12 +16,10 @@ browserSync({
     port: 4001
   },
   server: {
-    baseDir: 'dist'
+    baseDir: "dist"
   },
 
-  files: [
-    'src/*.html'
-  ],
+  files: ["src/*.html"],
 
   middleware: [historyApiFallback()]
 });

--- a/tools/enzymeTestAdapterSetup.js
+++ b/tools/enzymeTestAdapterSetup.js
@@ -1,4 +1,4 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 
 configure({ adapter: new Adapter() });

--- a/tools/fileMock.js
+++ b/tools/fileMock.js
@@ -1,3 +1,3 @@
 // Return an empty string or other mock path to emulate the url that
 // webpack provides via the file-loader
-module.exports = '';
+module.exports = "";

--- a/tools/nodeVersionCheck.js
+++ b/tools/nodeVersionCheck.js
@@ -1,10 +1,10 @@
 /* eslint-disable */
-var exec = require('child_process').exec;
+var exec = require("child_process").exec;
 
-exec('node -v', function (err, stdout) {
+exec("node -v", function(err, stdout) {
   if (err) throw err;
 
   if (parseFloat(stdout.slice(1)) < 4) {
-    throw new Error('React Slingshot requires node 4.0 or greater.');
+    throw new Error("React Slingshot requires node 4.0 or greater.");
   }
 });

--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -2,14 +2,14 @@
 // which supports hot reloading and synchronized testing.
 
 // Require Browsersync along with webpack and middleware for it
-import browserSync from 'browser-sync';
+import browserSync from "browser-sync";
 // Required for react-router browserHistory
 // see https://github.com/BrowserSync/browser-sync/issues/204#issuecomment-102623643
-import historyApiFallback from 'connect-history-api-fallback';
-import webpack from 'webpack';
-import webpackDevMiddleware from 'webpack-dev-middleware';
-import webpackHotMiddleware from 'webpack-hot-middleware';
-import config from '../webpack.config.dev';
+import historyApiFallback from "connect-history-api-fallback";
+import webpack from "webpack";
+import webpackDevMiddleware from "webpack-dev-middleware";
+import webpackHotMiddleware from "webpack-hot-middleware";
+import config from "../webpack.config.dev";
 
 const bundler = webpack(config);
 
@@ -20,7 +20,7 @@ browserSync({
     port: 3001
   },
   server: {
-    baseDir: 'src',
+    baseDir: "src",
 
     middleware: [
       historyApiFallback(),
@@ -40,7 +40,7 @@ browserSync({
           timings: false,
           chunks: false,
           chunkModules: false
-        },
+        }
 
         // for other settings see
         // https://webpack.js.org/guides/development/#using-webpack-dev-middleware
@@ -53,7 +53,5 @@ browserSync({
 
   // no need to watch '*.js' here, webpack will take care of it for us,
   // including full page reloads if HMR won't work
-  files: [
-    'src/*.html'
-  ]
+  files: ["src/*.html"]
 });

--- a/tools/startMessage.js
+++ b/tools/startMessage.js
@@ -1,5 +1,5 @@
-import {chalkSuccess} from './chalkConfig';
+import { chalkSuccess } from "./chalkConfig";
 
 /* eslint-disable no-console */
 
-console.log(chalkSuccess('Starting app in dev mode...'));
+console.log(chalkSuccess("Starting app in dev mode..."));

--- a/tools/testCi.js
+++ b/tools/testCi.js
@@ -1,16 +1,17 @@
-import {spawn} from 'child_process';
+import { spawn } from "child_process";
 
-const requiresHarmonyFlag = parseInt(/^v(\d+)\./.exec(process.version)[1], 10) < 7;
-const harmonyProxies = requiresHarmonyFlag ? ['--harmony_proxies'] : [];
+const requiresHarmonyFlag =
+  parseInt(/^v(\d+)\./.exec(process.version)[1], 10) < 7;
+const harmonyProxies = requiresHarmonyFlag ? ["--harmony_proxies"] : [];
 const args = [
   ...harmonyProxies,
-  'node_modules/jest/bin/jest',
+  "node_modules/jest/bin/jest",
   // First two args are always node and the script running, i.e. ['node', './tools/testCi.js', ...]
   ...process.argv.slice(2)
 ];
 
-const testCi = spawn('node', args);
+const testCi = spawn("node", args);
 const consoleLogger = data => console.log(`${data}`); // eslint-disable-line no-console
 
-testCi.stdout.on('data', consoleLogger);
-testCi.stderr.on('data', consoleLogger);
+testCi.stdout.on("data", consoleLogger);
+testCi.stderr.on("data", consoleLogger);


### PR DESCRIPTION
This PR does the following:

- Adds code formatting with prettier, adding it in the form of a npm script, and eslint plugin
- Adds git pre-commmit hooks that formats staged `.js` files with prettier
- Formats existing javascript code in `src/` and `tools/` with prettier

Lint scripts could also be added to the pre-commit hooks but for now I've just included the formatter.


  